### PR TITLE
:checkered_flag: Add nupkg extension

### DIFF
--- a/lib/archive-editor.coffee
+++ b/lib/archive-editor.coffee
@@ -7,7 +7,7 @@ Serializable = require 'serializable'
 
 isPathSupported = (filePath) ->
   switch path.extname(filePath)
-    when '.egg', '.epub', '.jar', '.love', '.tar', '.tgz', '.war', '.whl', '.xpi', '.zip'
+    when '.egg', '.epub', '.jar', '.love', '.tar', '.tgz', '.war', '.whl', '.xpi', '.zip', '.nupkg'
       return true
     when '.gz'
       return path.extname(path.basename(filePath, '.gz')) is '.tar'


### PR DESCRIPTION
Package files in NuGet are simply zip files with a different extension. You can just rename the file or append .zip and they show up great in Atom. It would be great to include this extension as one of the defaults so every .NET developer can have this great feature automatically!