### PR TITLE
Focus file before modifying DOM to avoid forced reflows

### DIFF
--- a/lib/archive-editor-view.js
+++ b/lib/archive-editor-view.js
@@ -68,7 +68,6 @@ export default class ArchiveEditorView {
         return
       }
 
-      this.refs.loadingMessage.style.display = 'none'
       if (error != null) {
         let message = 'Reading the archive file failed'
         if (error.message) {
@@ -80,6 +79,10 @@ export default class ArchiveEditorView {
         this.createTreeEntries(entries)
         this.updateSummary()
       }
+
+      // We hide the loading message _after_ creating the archive tree
+      // to avoid forced reflows.
+      this.refs.loadingMessage.style.display = 'none'
     })
   }
 
@@ -93,17 +96,22 @@ export default class ArchiveEditorView {
       if (entry.isDirectory()) {
         const entryView = new DirectoryView(this, index, this.path, entry)
         this.entries.push(entryView)
-        this.refs.tree.appendChild(entryView.element)
       } else {
         const entryView = new FileView(this, index, this.path, entry)
         this.entries.push(entryView)
-        this.refs.tree.appendChild(entryView.element)
       }
       index++
     }
 
-    this.refs.tree.style.display = ''
     this.selectFileAfterIndex(-1)
+
+    // Wait until selecting (focusing) the first file before appending the entries
+    // to avoid a double-forced reflow when focusing.
+    for (const entry of this.entries) {
+      this.refs.tree.appendChild(entry.element)
+    }
+
+    this.refs.tree.style.display = ''
   }
 
   updateSummary () {

--- a/lib/file-view.js
+++ b/lib/file-view.js
@@ -90,10 +90,16 @@ export default class FileView {
   }
 
   select () {
-    for (const selected of this.element.closest('.archive-editor').querySelectorAll('.selected')) {
-      selected.classList.remove('selected')
+    this.element.focus()
+
+    const archiveEditorElement = this.element.closest('.archive-editor')
+    // On initial tree creation, it is not possible for any entries to be selected
+    // (The entries also haven't been added to the DOM yet)
+    if (archiveEditorElement) {
+      for (const selected of archiveEditorElement.querySelectorAll('.selected')) {
+        selected.classList.remove('selected')
+      }
     }
     this.element.classList.add('selected')
-    this.element.focus()
   }
 }

--- a/styles/archive-view.less
+++ b/styles/archive-view.less
@@ -3,11 +3,11 @@
 .archive-editor {
   background-color: @inset-panel-background-color;
   overflow: auto;
-  contain: strict;
 
   .archive-container {
     height: 100%;
     width: 100%;
+    contain: strict;
 
     .inset-panel {
       border-width: 0;
@@ -15,10 +15,10 @@
       .panel-heading {
         border-radius: 0;
       }
-    }
 
-    .archive-tree {
-      padding: 5px;
+      .archive-tree {
+        padding: 5px;
+      }
     }
   }
 }

--- a/styles/archive-view.less
+++ b/styles/archive-view.less
@@ -3,11 +3,11 @@
 .archive-editor {
   background-color: @inset-panel-background-color;
   overflow: auto;
+  contain: strict;
 
   .archive-container {
     height: 100%;
     width: 100%;
-    contain: strict;
 
     .inset-panel {
       border-width: 0;

--- a/styles/archive-view.less
+++ b/styles/archive-view.less
@@ -3,9 +3,10 @@
 .archive-editor {
   background-color: @inset-panel-background-color;
   overflow: auto;
+  contain: strict;
 
   .archive-container {
-    height:100%;
+    height: 100%;
     width: 100%;
 
     .inset-panel {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Focusing an element is considered a "read" operation.  Since we were mutating the DOM before selecting the element, the focus call was causing a double forced reflow.  By waiting until after the focus call to mutate the DOM, we avoid those forced reflows, which were taking ~220ms combined.  While reflows still have to occur, they seem to be more efficient than the forced reflows as seen below.  I've also set `contain: strict` on the Archive View to improve layout performance.

| Before | After |
| ------- | ------ |
| 1484ms ![forced-reflows](https://user-images.githubusercontent.com/2766036/33776699-85479d74-dc42-11e7-94a6-92f09d1e7168.png) | 1200ms ![regular-reflow](https://user-images.githubusercontent.com/2766036/33780917-cf80ba78-dc52-11e7-90dc-6bddbdf1e834.png) |

### Alternate Designs

Don't focus a file on creation.  That however is not very user-friendly.

### Benefits

Removes a source of forced reflows and minorly improves the time it takes until the Archive View is usable.

### Possible Drawbacks

If an exception occurs while creating the tree entries or updating the summary, the loading view will not be removed.  Similarly with selecting the first file and actually adding the entries to the DOM.

### Applicable Issues

Refs #19