### PR TITLE
Deactivate package properly

### DIFF
--- a/lib/archive-editor.js
+++ b/lib/archive-editor.js
@@ -9,12 +9,21 @@ module.exports =
 
 class ArchiveEditor {
   static activate () {
-    return atom.workspace.addOpener((filePath = '') => {
+    this.disposable = atom.workspace.addOpener((filePath = '') => {
       // Check that filePath exists before opening, in case a remote URI was given
       if (isPathSupported(filePath) && fs.isFileSync(filePath)) {
         return new ArchiveEditor({path: filePath})
       }
     })
+  }
+
+  static deactivate () {
+    this.disposable.dispose()
+    for (const item of atom.workspace.getPaneItems()) {
+      if (item instanceof ArchiveEditor) {
+        item.destroy()
+      }
+    }
   }
 
   static consumeElementIcons (service) {

--- a/spec/archive-editor-spec.coffee
+++ b/spec/archive-editor-spec.coffee
@@ -21,3 +21,23 @@ describe "ArchiveEditor", ->
       editor = new ArchiveEditor(path: path.join(__dirname, 'fixtures', 'nested.tar'))
       newEditor = editor.copy()
       expect(newEditor.getPath()).toBe(editor.getPath())
+
+  describe ".deactivate()", ->
+    it "removes all ArchiveEditors from the workspace and does not open any new ones", ->
+      waitsForPromise -> atom.packages.activatePackage('archive-view')
+      waitsForPromise -> atom.workspace.open(path.join(__dirname, 'fixtures', 'nested.tar'))
+      waitsForPromise -> atom.workspace.open(path.join(__dirname, 'fixtures', 'invalid.zip'))
+      waitsForPromise -> atom.workspace.open()
+
+      runs ->
+        expect(atom.workspace.getPaneItems().filter((item) -> item instanceof ArchiveEditor).length).toBe(2)
+
+      waitsForPromise -> atom.packages.deactivatePackage('archive-view')
+
+      runs ->
+        expect(atom.workspace.getPaneItems().filter((item) -> item instanceof ArchiveEditor).length).toBe(0)
+
+      waitsForPromise -> atom.workspace.open(path.join(__dirname, 'fixtures', 'nested.tar'))
+
+      runs ->
+        expect(atom.workspace.getPaneItems().filter((item) -> item instanceof ArchiveEditor).length).toBe(0)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

On package deactivation, dispose of the workspace opener subscription and remove all ArchiveEditorViews from the workspace.

### Alternate Designs

None.

### Benefits

This package will shut down properly.

### Possible Drawbacks

None.

### Applicable Issues

None.