### PR TITLE
Refactor

### DIFF
--- a/lib/archive-editor-view.js
+++ b/lib/archive-editor-view.js
@@ -4,35 +4,33 @@
 import fs from 'fs-plus'
 import humanize from 'humanize-plus'
 import archive from 'ls-archive'
-import {CompositeDisposable, Disposable} from 'atom'
+import {CompositeDisposable, Disposable, Emitter, File} from 'atom'
 import etch from 'etch'
 
 import FileView from './file-view'
 import DirectoryView from './directory-view'
 
 export default class ArchiveEditorView {
-  constructor (editor) {
+  constructor (archivePath) {
     this.disposables = new CompositeDisposable()
+    this.emitter = new Emitter()
+    this.file = new File(archivePath)
     this.entries = []
     etch.initialize(this)
-    this.setModel(editor)
 
-    const focusHandler = () => {
-      this.focusSelectedFile()
-    }
+    this.refresh()
+
+    this.disposables.add(this.file.onDidChange(() => this.refresh()))
+    this.disposables.add(this.file.onDidRename(() => this.refresh()))
+    this.disposables.add(this.file.onDidDelete(() => this.destroy()))
+
+    const focusHandler = () => this.focusSelectedFile()
+
     this.element.addEventListener('focus', focusHandler)
-    this.disposables.add(new Disposable(() => { this.element.removeEventListener('focus', focusHandler) }))
+    this.disposables.add(new Disposable(() => this.element.removeEventListener('focus', focusHandler)))
   }
 
   update () {}
-
-  destroy () {
-    while (this.entries.length > 0) {
-      this.entries.pop().destroy()
-    }
-    this.disposables.dispose()
-    return etch.destroy(this)
-  }
 
   render () {
     return (
@@ -49,11 +47,40 @@ export default class ArchiveEditorView {
     )
   }
 
-  setPath (path) {
-    if (path && this.path !== path) {
-      this.path = path
-      this.refresh()
+  copy () {
+    return new ArchiveEditorView(this.getPath())
+  }
+
+  destroy () {
+    while (this.entries.length > 0) {
+      this.entries.pop().destroy()
     }
+    this.disposables.dispose()
+    this.emitter.emit('did-destroy')
+    etch.destroy(this)
+  }
+
+  onDidDestroy (callback) {
+    return this.emitter.on('did-destroy', callback)
+  }
+
+  serialize () {
+    return {
+      deserializer: this.constructor.name,
+      path: this.getPath()
+    }
+  }
+
+  getPath () {
+    return this.file.getPath()
+  }
+
+  getTitle () {
+    return this.getPath() ? this.file.getBaseName() : 'untitled'
+  }
+
+  getURI () {
+    return this.getPath()
   }
 
   refresh () {
@@ -62,9 +89,9 @@ export default class ArchiveEditorView {
     this.refs.loadingMessage.style.display = ''
     this.refs.errorMessage.style.display = 'none'
 
-    const originalPath = this.path
-    archive.list(this.path, {tree: true}, (error, entries) => {
-      if (originalPath !== this.path) {
+    const originalPath = this.getPath()
+    archive.list(this.getPath(), {tree: true}, (error, entries) => {
+      if (originalPath !== this.getPath()) {
         return
       }
 
@@ -91,11 +118,11 @@ export default class ArchiveEditorView {
     let index = 0
     for (const entry of entries) {
       if (entry.isDirectory()) {
-        const entryView = new DirectoryView(this, index, this.path, entry)
+        const entryView = new DirectoryView(this, index, this.getPath(), entry)
         this.entries.push(entryView)
         this.refs.tree.appendChild(entryView.element)
       } else {
-        const entryView = new FileView(this, index, this.path, entry)
+        const entryView = new FileView(this, index, this.getPath(), entry)
         this.entries.push(entryView)
         this.refs.tree.appendChild(entryView.element)
       }
@@ -114,7 +141,7 @@ export default class ArchiveEditorView {
     const directoryLabel = directoryCount === 1 ? '1 folder' : `${humanize.intComma(directoryCount)} folders`
 
     this.refs.summary.style.display = ''
-    this.refs.summary.textContent = `${humanize.fileSize(fs.getSizeSync(this.path))} with ${fileLabel} and ${directoryLabel}`
+    this.refs.summary.textContent = `${humanize.fileSize(fs.getSizeSync(this.getPath()))} with ${fileLabel} and ${directoryLabel}`
   }
 
   focusSelectedFile () {
@@ -154,23 +181,5 @@ export default class ArchiveEditorView {
 
   focus () {
     this.focusSelectedFile()
-  }
-
-  setModel (editor) {
-    if (!editor) {
-      return
-    }
-
-    this.editor = editor
-    this.setPath(this.editor.getPath())
-    this.disposables.add(this.editor.file.onDidChange(() => {
-      this.refresh()
-    }))
-    this.disposables.add(this.editor.file.onDidDelete(() => {
-      const pane = atom.workspace.paneForItem(this.editor)
-      if (pane) {
-        pane.destroyItem(this.editor)
-      }
-    }))
   }
 }

--- a/lib/archive-editor-view.js
+++ b/lib/archive-editor-view.js
@@ -14,7 +14,8 @@ export default class ArchiveEditorView {
   constructor (archivePath) {
     this.disposables = new CompositeDisposable()
     this.emitter = new Emitter()
-    this.file = new File(archivePath)
+    this.path = archivePath
+    this.file = new File(this.path)
     this.entries = []
     etch.initialize(this)
 
@@ -48,7 +49,7 @@ export default class ArchiveEditorView {
   }
 
   copy () {
-    return new ArchiveEditorView(this.getPath())
+    return new ArchiveEditorView(this.path)
   }
 
   destroy () {
@@ -64,10 +65,14 @@ export default class ArchiveEditorView {
     return this.emitter.on('did-destroy', callback)
   }
 
+  onDidChangeTitle (callback) {
+    return this.emitter.on('did-change-title', callback)
+  }
+
   serialize () {
     return {
       deserializer: this.constructor.name,
-      path: this.getPath()
+      path: this.path
     }
   }
 
@@ -76,11 +81,11 @@ export default class ArchiveEditorView {
   }
 
   getTitle () {
-    return this.getPath() ? this.file.getBaseName() : 'untitled'
+    return this.path ? this.file.getBaseName() : 'untitled'
   }
 
   getURI () {
-    return this.getPath()
+    return this.path
   }
 
   refresh () {
@@ -89,9 +94,14 @@ export default class ArchiveEditorView {
     this.refs.loadingMessage.style.display = ''
     this.refs.errorMessage.style.display = 'none'
 
-    const originalPath = this.getPath()
-    archive.list(this.getPath(), {tree: true}, (error, entries) => {
-      if (originalPath !== this.getPath()) {
+    if (this.path !== this.getPath()) {
+      this.path = this.getPath()
+      this.emitter.emit('did-change-title')
+    }
+
+    const originalPath = this.path
+    archive.list(this.path, {tree: true}, (error, entries) => {
+      if (originalPath !== this.path) {
         return
       }
 
@@ -118,11 +128,11 @@ export default class ArchiveEditorView {
     let index = 0
     for (const entry of entries) {
       if (entry.isDirectory()) {
-        const entryView = new DirectoryView(this, index, this.getPath(), entry)
+        const entryView = new DirectoryView(this, index, this.path, entry)
         this.entries.push(entryView)
         this.refs.tree.appendChild(entryView.element)
       } else {
-        const entryView = new FileView(this, index, this.getPath(), entry)
+        const entryView = new FileView(this, index, this.path, entry)
         this.entries.push(entryView)
         this.refs.tree.appendChild(entryView.element)
       }
@@ -141,7 +151,7 @@ export default class ArchiveEditorView {
     const directoryLabel = directoryCount === 1 ? '1 folder' : `${humanize.intComma(directoryCount)} folders`
 
     this.refs.summary.style.display = ''
-    this.refs.summary.textContent = `${humanize.fileSize(fs.getSizeSync(this.getPath()))} with ${fileLabel} and ${directoryLabel}`
+    this.refs.summary.textContent = `${humanize.fileSize(fs.getSizeSync(this.path))} with ${fileLabel} and ${directoryLabel}`
   }
 
   focusSelectedFile () {

--- a/lib/archive-editor.js
+++ b/lib/archive-editor.js
@@ -1,89 +1,45 @@
 const fs = require('fs-plus')
 const path = require('path')
-const {Disposable, Emitter, File} = require('atom')
+const {Disposable} = require('atom')
 
 const getIconServices = require('./get-icon-services')
 const ArchiveEditorView = require('./archive-editor-view')
 
-module.exports =
-
-class ArchiveEditor {
-  static activate () {
+module.exports = {
+  activate () {
     this.disposable = atom.workspace.addOpener((filePath = '') => {
       // Check that filePath exists before opening, in case a remote URI was given
       if (isPathSupported(filePath) && fs.isFileSync(filePath)) {
-        return new ArchiveEditor({path: filePath})
+        return new ArchiveEditorView(filePath)
       }
     })
-  }
+  },
 
-  static deactivate () {
+  deactivate () {
     this.disposable.dispose()
     for (const item of atom.workspace.getPaneItems()) {
-      if (item instanceof ArchiveEditor) {
+      if (item instanceof ArchiveEditorView) {
         item.destroy()
       }
     }
-  }
+  },
 
-  static consumeElementIcons (service) {
+  consumeElementIcons (service) {
     getIconServices().setElementIcons(service)
     return new Disposable(() => getIconServices().resetElementIcons())
-  }
+  },
 
-  static consumeFileIcons (service) {
+  consumeFileIcons (service) {
     getIconServices().setFileIcons(service)
     return new Disposable(() => getIconServices().resetFileIcons())
-  }
+  },
 
-  static deserialize (params = {}) {
+  deserialize (params = {}) {
     if (fs.isFileSync(params.path)) {
-      return new ArchiveEditor({path: params.path})
+      return new ArchiveEditorView(params.path)
     } else {
-      console.warn(`Can't build ArchiveEditor for path "${params.path}"; file no longer exists`)
+      console.warn(`Can't build ArchiveEditorView for path "${params.path}"; file no longer exists`)
     }
-  }
-
-  constructor ({path}) {
-    this.emitter = new Emitter()
-    this.file = new File(path)
-    this.view = new ArchiveEditorView(this)
-    this.element = this.view.element
-  }
-
-  copy () {
-    return new ArchiveEditor({
-      path: this.getPath()
-    })
-  }
-
-  destroy () {
-    this.view.destroy()
-    this.emitter.emit('did-destroy')
-  }
-
-  onDidDestroy (callback) {
-    return this.emitter.on('did-destroy', callback)
-  }
-
-  serialize () {
-    return {
-      deserializer: this.constructor.name,
-      path: this.getPath()
-    }
-  }
-
-  getPath () {
-    return this.file.getPath()
-  }
-
-  getTitle () {
-    const fullPath = this.getPath()
-    return fullPath ? path.basename(fullPath) : 'untitled'
-  }
-
-  getURI () {
-    return this.getPath()
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "atom": "*"
   },
   "deserializers": {
+    "ArchiveEditor": "deserialize",
     "ArchiveEditorView": "deserialize"
   },
   "consumedServices": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "atom": "*"
   },
   "deserializers": {
-    "ArchiveEditor": "deserialize"
+    "ArchiveEditorView": "deserialize"
   },
   "consumedServices": {
     "atom.file-icons": {

--- a/spec/archive-editor-spec.coffee
+++ b/spec/archive-editor-spec.coffee
@@ -1,11 +1,12 @@
 path = require 'path'
 ArchiveEditor = require '../lib/archive-editor'
+ArchiveEditorView = require '../lib/archive-editor-view'
 
 describe "ArchiveEditor", ->
   describe ".deserialize", ->
     it "returns undefined if no file exists at the given path", ->
       spyOn(console, 'warn') # Don't log during specs
-      editor1 = new ArchiveEditor(path: path.join(__dirname, 'fixtures', 'nested.tar'))
+      editor1 = new ArchiveEditorView(path.join(__dirname, 'fixtures', 'nested.tar'))
       state = editor1.serialize()
       editor1.destroy()
 
@@ -16,28 +17,22 @@ describe "ArchiveEditor", ->
       state.path = 'bogus'
       expect(ArchiveEditor.deserialize(state)).toBeUndefined()
 
-  describe ".copy()", ->
-    it "returns a new ArchiveEditor for the same file", ->
-      editor = new ArchiveEditor(path: path.join(__dirname, 'fixtures', 'nested.tar'))
-      newEditor = editor.copy()
-      expect(newEditor.getPath()).toBe(editor.getPath())
-
   describe ".deactivate()", ->
-    it "removes all ArchiveEditors from the workspace and does not open any new ones", ->
+    it "removes all ArchiveEditorViews from the workspace and does not open any new ones", ->
       waitsForPromise -> atom.packages.activatePackage('archive-view')
       waitsForPromise -> atom.workspace.open(path.join(__dirname, 'fixtures', 'nested.tar'))
       waitsForPromise -> atom.workspace.open(path.join(__dirname, 'fixtures', 'invalid.zip'))
       waitsForPromise -> atom.workspace.open()
 
       runs ->
-        expect(atom.workspace.getPaneItems().filter((item) -> item instanceof ArchiveEditor).length).toBe(2)
+        expect(atom.workspace.getPaneItems().filter((item) -> item instanceof ArchiveEditorView).length).toBe(2)
 
       waitsForPromise -> atom.packages.deactivatePackage('archive-view')
 
       runs ->
-        expect(atom.workspace.getPaneItems().filter((item) -> item instanceof ArchiveEditor).length).toBe(0)
+        expect(atom.workspace.getPaneItems().filter((item) -> item instanceof ArchiveEditorView).length).toBe(0)
 
       waitsForPromise -> atom.workspace.open(path.join(__dirname, 'fixtures', 'nested.tar'))
 
       runs ->
-        expect(atom.workspace.getPaneItems().filter((item) -> item instanceof ArchiveEditor).length).toBe(0)
+        expect(atom.workspace.getPaneItems().filter((item) -> item instanceof ArchiveEditorView).length).toBe(0)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This refactors archive-view to be more in line with how similar packages are designed.  Notable changes:
* Remove `ArchiveEditor` class and make the entry file an object instead of a class
* Move all view instantiation to `ArchiveEditorView` instead of splitting it between `ArchiveEditor` and `ArchiveEditorView`
* Move all pane item methods to `ArchiveEditorView`
* Move file event listeners into the `ArchiveEditorView` constructor and remove the confusingly-named `setModel` method
* Update title and archive view on file rename

### Alternate Designs

None.

### Benefits

Better separation of concerns between `ArchiveEditor` (package lifecycle and services) and `ArchiveEditorView` (the view and pane item).

### Possible Drawbacks

Unintentionally-introduced bugs as a result of the file restructuring.
~~This might also break any saved state that was relying on the `ArchiveEditor` deserializer name instead of the new `ArchiveEditorView`.  I'll have to look through the commit history and then implement a shim if necessary.~~
I've added back the old `ArchiveEditor` deserializer to ensure smooth transitions to the new deserializer.  After a few versions have passed it should be safe to remove it.

### Applicable Issues

None.