### PR TITLE
⬆️ ls-archive@1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "etch": "0.9.0",
     "fs-plus": "^3.0.0",
     "humanize-plus": "~1.8.2",
-    "ls-archive": "^1.2.4",
+    "ls-archive": "^1.2.5",
     "temp": "~0.8.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "etch": "0.9.0",
     "fs-plus": "^3.0.0",
     "humanize-plus": "~1.8.2",
-    "ls-archive": "^1.2.1",
+    "ls-archive": "^1.2.4",
     "temp": "~0.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
In support of https://github.com/atom/atom/pull/17273, this pull request updates the dependency on ls-archive to v1.2.5.

/xref https://github.com/atom/node-ls-archive/pull/10