### PR TITLE
Fix async timing issue in tests

### DIFF
--- a/spec/archive-editor-spec.js
+++ b/spec/archive-editor-spec.js
@@ -1,3 +1,5 @@
+const {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise} = require('./async-spec-helpers') // eslint-disable-line no-unused-vars
+
 const path = require('path')
 const ArchiveEditor = require('../lib/archive-editor')
 const ArchiveEditorView = require('../lib/archive-editor-view')

--- a/spec/archive-editor-view-spec.js
+++ b/spec/archive-editor-view-spec.js
@@ -1,6 +1,6 @@
 const {Disposable, File} = require('atom')
 const getIconServices = require('../lib/get-icon-services')
-const {beforeEach, conditionPromise, it} = require('./async-spec-helpers')
+const {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise} = require('./async-spec-helpers') // eslint-disable-line no-unused-vars
 
 async function condition (handler) {
   if (jasmine.isSpy(window.setTimeout)) {


### PR DESCRIPTION
Prior to this change, `spec/archive-editor-spec.js` made use of async operations, but it didn't use the requisite async spec helpers. This led to flaky test failures like the one seen in https://circleci.com/gh/atom/atom/7468.




