### PR TITLE
⬆️ ls-archive@1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "etch": "0.9.0",
     "fs-plus": "^3.0.0",
     "humanize-plus": "~1.8.2",
-    "ls-archive": "1.3.0",
+    "ls-archive": "1.3.1",
     "temp": "~0.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrades ls-archive from 1.3.0 to 1.3.1 to pull in the fixes from https://github.com/atom/node-ls-archive/pull/13. This should resolve the [CI failures](https://ci.appveyor.com/project/Atom/archive-view/build/79) that archive-view is experiencing.
