### PR TITLE
👕Pin linter to standard v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "temp": "~0.8.1"
   },
   "devDependencies": {
-    "standard": "*"
+    "standard": "^11.0.1"
   },
   "standard": {
     "env": {


### PR DESCRIPTION
### Description of the Change

Prior to this change, this package depended on the latest version of `standard`. `standard` 12 was recently released, and it introduced changes to the linter rules. As a result, the [latest commit](https://github.com/atom/archive-view/commit/e2b57e2774a87e40df3262d344573b8b388e486b) on master [passed CI](https://ci.appveyor.com/project/Atom/archive-view/build/89) when it was first pushed to this repository 3 months ago, but it [fails CI now](https://ci.appveyor.com/project/Atom/archive-view/build/92) due to the changes in `standard` 12.

In https://github.com/atom/styleguide/pull/70#issuecomment-422128831, we decided to stick with the linter rules from `standard` 11 for now. Therefore, this pull request updates this package to depend on `standard` 11.

### Alternate Designs

See https://github.com/atom/styleguide/pull/70#issuecomment-422128831

### Benefits

Fixes CI. 

### Possible Drawbacks

See https://github.com/atom/styleguide/pull/70#issuecomment-422128831
