### PR TITLE
:sparkles: Support tar files wrapped with bzip2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Adds support for browsing archive files in Atom with the following extensions:
 * `.tar`
 * `.tar.gz`
 * `.tgz`
+* `.tar.bz2`
+* `.tbz`
+* `.tbz2`
 * `.war`
 * `.whl`
 * `.xpi`

--- a/lib/archive-editor.js
+++ b/lib/archive-editor.js
@@ -52,6 +52,8 @@ function isPathSupported (filePath) {
     case '.nupkg':
     case '.tar':
     case '.tgz':
+    case '.tbz':
+    case '.tbz2':
     case '.war':
     case '.whl':
     case '.xpi':
@@ -59,6 +61,8 @@ function isPathSupported (filePath) {
       return true
     case '.gz':
       return path.extname(path.basename(filePath, '.gz')) === '.tar'
+    case '.bz2':
+      return path.extname(path.basename(filePath, '.bz2')) === '.tar'
     default:
       return false
   }


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

With https://github.com/atom/node-ls-archive/commit/fa6c8d30c9f01b254cde7f5f30e0bd56bd89b763 I added `.tar.bz2` support to ls-archive which underpins this package.
This commit just allows the relevant file extensions.

Note that this requires a new release of ls-archive first.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None

### Benefits

<!-- What benefits will be realized by the code change? -->

Tar archives wrapped with bzip2 can be opened.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None

### Applicable Issues

<!-- Enter any applicable Issues here -->
